### PR TITLE
[atlantis] Bump to 0.17.3. Add terragrunt-atlantis-config 1.7.2

### DIFF
--- a/.images/atlantis/Dockerfile
+++ b/.images/atlantis/Dockerfile
@@ -4,7 +4,7 @@ ARG DEFAULT_TERRAGRUNT_VERSION
 
 # Download Terragrunt
 # Latest patch versions are included
-RUN TERRAGRUNT_VERSIONS="0.21.13 0.22.5 0.23.40 0.24.4 0.25.5 0.26.7 0.27.4 0.28.7 ${DEFAULT_TERRAGRUNT_VERSION}" && \
+RUN TERRAGRUNT_VERSIONS="0.23.40 0.28.7 0.28.24 0.31.8 ${DEFAULT_TERRAGRUNT_VERSION}" && \
     for VERSION in ${TERRAGRUNT_VERSIONS}; do \
         curl -LOs https://github.com/gruntwork-io/terragrunt/releases/download/v${VERSION}/terragrunt_linux_amd64 && \
         curl -LOs https://github.com/gruntwork-io/terragrunt/releases/download/v${VERSION}/SHA256SUMS && \
@@ -17,3 +17,10 @@ RUN TERRAGRUNT_VERSIONS="0.21.13 0.22.5 0.23.40 0.24.4 0.25.5 0.26.7 0.27.4 0.28
     done && \
     ln -sv /usr/local/bin/tg/versions/${DEFAULT_TERRAGRUNT_VERSION}/terragrunt /usr/local/bin/terragrunt
 
+# Download terragrunt-atlantis-config
+ARG TERRAGRUNT_ATLANTIS_CONFIG_VERSION
+RUN curl -LOs https://github.com/transcend-io/terragrunt-atlantis-config/releases/download/v${TERRAGRUNT_ATLANTIS_CONFIG_VERSION}/terragrunt-atlantis-config_${TERRAGRUNT_ATLANTIS_CONFIG_VERSION}_linux_amd64.tar.gz && \
+  tar zxf terragrunt-atlantis-config_${TERRAGRUNT_ATLANTIS_CONFIG_VERSION}_linux_amd64.tar.gz && \
+  chmod +x terragrunt-atlantis-config_${TERRAGRUNT_ATLANTIS_CONFIG_VERSION}_linux_amd64/terragrunt-atlantis-config_${TERRAGRUNT_ATLANTIS_CONFIG_VERSION}_linux_amd64 && \
+  mv terragrunt-atlantis-config_${TERRAGRUNT_ATLANTIS_CONFIG_VERSION}_linux_amd64/terragrunt-atlantis-config_${TERRAGRUNT_ATLANTIS_CONFIG_VERSION}_linux_amd64 /usr/local/bin/terragrunt-atlantis-config && \
+  rm -rf terragrunt-atlantis-config_${TERRAGRUNT_ATLANTIS_CONFIG_VERSION}_linux_amd64

--- a/.images/atlantis/Makefile
+++ b/.images/atlantis/Makefile
@@ -2,16 +2,18 @@
 
 ECR_REPO:=thirdparty/atlantis
 
-ATLANTIS_VERSION=0.17.1
+ATLANTIS_VERSION=0.17.3
 TERRAGRUNT_VERSION=0.23.40
-VERSION:=0.0.10
+TERRAGRUNT_ATLANTIS_CONFIG_VERSION=1.7.2
+VERSION:=0.0.11
 TAG:=$(ECR_REGISTRY_URL)/$(ECR_REPO):$(VERSION)
 
 build: Dockerfile
-	docker build --rm \
-		--build-arg ATLANTIS_VERSION=$(ATLANTIS_VERSION) \
-		--build-arg DEFAULT_TERRAGRUNT_VERSION=$(TERRAGRUNT_VERSION) \
-		-t $(TAG) .
+  docker build --rm \
+    --build-arg ATLANTIS_VERSION=$(ATLANTIS_VERSION) \
+    --build-arg DEFAULT_TERRAGRUNT_VERSION=$(TERRAGRUNT_VERSION) \
+    --build-arg TERRAGRUNT_ATLANTIS_CONFIG_VERSION=$(TERRAGRUNT_ATLANTIS_CONFIG_VERSION) \
+    -t $(TAG) .
 
 docker/login:
 	$$(aws ecr get-login --no-include-email --region $(ECR_REGION))


### PR DESCRIPTION
- Bump atlantis base image to [0.17.3](https://github.com/runatlantis/atlantis/releases/tag/v0.17.3)
- Add terragrunt-atlantis-config [1.7.2](https://github.com/transcend-io/terragrunt-atlantis-config/releases/tag/v1.7.2)