### PR TITLE
Use rbac.authorization.k8s.io/v1 and policy/v1

### DIFF
--- a/charts/airflow-kube-s3/CHANGELOG.md
+++ b/charts/airflow-kube-s3/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Airflow chart changelog
 
+## 0.1.0
+
+- Use rbac.authorization.k8s.io/v1
+
 ## 0.0.3
 
 - Set `AIRFLOW__SCHEDULER__STATSD_HOST` env to hostIP in scheduler deployment

--- a/charts/airflow-kube-s3/Chart.yaml
+++ b/charts/airflow-kube-s3/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Airflow running with KubernetesExecutor, git-sync and logs to s3
 name: airflow-kube-s3
-version: 0.0.15
+version: 0.1.0
 appVersion: 1.10.14
 icon: https://usr/local/airflow.apache.org/_images/pin_large.png
 home: https://usr/local/airflow.apache.org/

--- a/charts/airflow-kube-s3/templates/pdb-scheduler.yaml
+++ b/charts/airflow-kube-s3/templates/pdb-scheduler.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.airflow.scheduler.podDisruptionBudgetEnabled }}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "airflow-kube-s3.fullname" . }}-scheduler

--- a/charts/airflow-kube-s3/templates/role.yaml
+++ b/charts/airflow-kube-s3/templates/role.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.rbac.create }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ template "airflow-kube-s3.fullname" . }}

--- a/charts/airflow-kube-s3/templates/rolebinding.yaml
+++ b/charts/airflow-kube-s3/templates/rolebinding.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.rbac.create }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ template "airflow-kube-s3.fullname" . }}


### PR DESCRIPTION
# Motivation

**rbac.authorization.k8s.io/v1beta1** is no longer supported in kubernetes 1.22. Need to be upgraded to **rbac.authorization.k8s.io/v1**

Ref: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#rbac-resources-v122 